### PR TITLE
Support `JSON` v1 and add CI workflow

### DIFF
--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -1,0 +1,40 @@
+name: CI
+
+on:
+  push:
+    branches: [master]
+    tags: ['*']
+  pull_request:
+  workflow_dispatch: 
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: ${{ github.ref != 'refs/heads/master' }}
+
+jobs:
+  test:
+    name: Julia ${{ matrix.version }} - ubuntu-latest
+    runs-on: ubuntu-latest
+    timeout-minutes: 30
+    strategy:
+      fail-fast: false
+      matrix:
+        version: ['1']
+    steps:
+      - uses: actions/checkout@v4
+
+      # test/runtests.jl expects Redis at localhost:55000 with password "redispw"
+      - name: Start Redis
+        run: |
+          docker run -d --name fxp-redis -p 55000:6379 redis:7-alpine redis-server --requirepass redispw
+          timeout 30 bash -c 'until docker exec fxp-redis redis-cli -a redispw --no-auth-warning ping | grep -q PONG; do sleep 1; done'
+
+      - uses: julia-actions/setup-julia@v2
+        with:
+          version: ${{ matrix.version }}
+
+      - uses: julia-actions/cache@v2
+
+      - uses: julia-actions/julia-buildpkg@v1
+
+      - uses: julia-actions/julia-runtest@v1

--- a/Project.toml
+++ b/Project.toml
@@ -8,6 +8,6 @@ JSON = "682c06a0-de6a-54ab-a142-c8b1cf79cde6"
 Jedis = "b89ccfe0-2c5f-46f6-b89b-da3e1c2e286f"
 
 [compat]
-JSON = "0.21"
+JSON = "0.21, 1"
 Jedis = "0.3"
 julia = "1"

--- a/src/FuseExchangeProtocol.jl
+++ b/src/FuseExchangeProtocol.jl
@@ -44,7 +44,7 @@ function json_pop(client::Jedis.Client, session_id::String, service_name::String
     if raw_data === nothing
         return nothing
     end
-    return Dict(Symbol(k) => v for (k, v) in JSON.parse(raw_data))
+    return Dict(Symbol(k) => v for (k, v) in JSON.parse(raw_data; allownan=true))
 end
 
 export json_pop

--- a/test/Project.toml
+++ b/test/Project.toml
@@ -1,4 +1,3 @@
 [deps]
 BenchmarkTools = "6e4b80f9-dd63-53aa-95a3-0cdb28fa8baf"
-Pkg = "44cfe95a-1eb2-52ea-b672-e2afdf69b78f"
 Test = "8dfed614-e22c-5e08-85e1-65c5234f0b40"

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -1,5 +1,3 @@
-import Pkg
-Pkg.activate(@__DIR__)
 import FuseExchangeProtocol as FXP
 import BenchmarkTools
 


### PR DESCRIPTION
## Summary

- Widen compat to `JSON = "0.21, 1"`
  - `json_pop`: add `allownan=true` to `JSON.parse` — JSON v1 rejects NaN by default, while v0.21 accepted it; this preserves the old behavior
- Add CI workflow (`CI.yml`)